### PR TITLE
Adjust test configs to split unit and integration tests

### DIFF
--- a/jest.backend.config.js
+++ b/jest.backend.config.js
@@ -13,7 +13,7 @@ export default {
     "<rootDir>/middlewares/*.test.js",
     "<rootDir>/models/*.test.js",
   ],
-  testPathIgnorePatterns: ["<rootDir>/client/"],
+  testPathIgnorePatterns: ["<rootDir>/client/", "<rootDir>/.*\\.integration\\.test\\.js$"],
   
   // jest code coverage
   collectCoverage: true,
@@ -23,6 +23,8 @@ export default {
     "models/**",
     "routes/**",
     "helpers/**",
+    "!**/*.test.js",
+    "!**/*.integration.test.js",
   ],
   coverageThreshold: {
     global: {

--- a/jest.backend.integration.config.js
+++ b/jest.backend.integration.config.js
@@ -7,6 +7,7 @@ export default {
 
   // which test to run
   testMatch: [
+    "<rootDir>/**/__tests__/**/*.integration.test.js",
     "<rootDir>/controllers/*.integration.test.js",
     "<rootDir>/helpers/*.integration.test.js",
     "<rootDir>/middlewares/*.integration.test.js",
@@ -22,6 +23,8 @@ export default {
     "models/**",
     "routes/**",
     "helpers/**",
+    "!**/*.test.js",
+    "!**/*.integration.test.js",
   ],
   coverageThreshold: {
     global: {

--- a/jest.frontend.config.js
+++ b/jest.frontend.config.js
@@ -29,10 +29,12 @@ export default {
     "<rootDir>/client/src/context/*.test.js",
     "<rootDir>/client/src/**/__tests__/**/*.test.js"
   ],
+  testPathIgnorePatterns: ["<rootDir>/client/.*\\.integration\\.test\\.js$"],
 
   // jest code coverage
   collectCoverage: true,
-  collectCoverageFrom: ["client/src/pages/**", "client/src/components/**", "client/src/hooks/**", "client/src/context/**"],
+  collectCoverageFrom: ["client/src/pages/**", "client/src/components/**", "client/src/hooks/**", "client/src/context/**", 
+    "!client/**/*.test.js", "!client/**/*.integration.test.js",],
   coverageThreshold: {
     global: {
       lines: 0,

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "sonarqube-scanner": "^4.3.4"
+    "mongodb-memory-server": "^11.0.1",
+    "sonarqube-scanner": "^4.3.4",
+    "supertest": "^7.2.2"
   }
 }


### PR DESCRIPTION
Fixes #202 

- Code coverage now no longer tracks unit and integration tests
- frontend and backend command no longer tests integration tests